### PR TITLE
Don't queue objects that don't have a SearchIndex

### DIFF
--- a/queued_search/management/commands/process_search_queue.py
+++ b/queued_search/management/commands/process_search_queue.py
@@ -284,8 +284,10 @@ class Command(NoArgsCommand):
             pks = []
 
             for obj_identifier in obj_identifiers:
-                current_index.remove_object(obj_identifier, using=self.using)
-                pks.append(self.split_obj_identifier(obj_identifier)[1])
+                pk = self.split_obj_identifier(obj_identifier)[1]
+                instance = self.get_instance(model_class, pk)
+                current_index.remove_object(instance, using=self.using)
+                pks.append(pk)
                 self.processed_deletes.add(obj_identifier)
 
             self.log.debug("Deleted objects for '%s': %s" % (object_path, ", ".join(pks)))

--- a/queued_search/management/commands/process_search_queue.py
+++ b/queued_search/management/commands/process_search_queue.py
@@ -284,10 +284,8 @@ class Command(NoArgsCommand):
             pks = []
 
             for obj_identifier in obj_identifiers:
-                pk = self.split_obj_identifier(obj_identifier)[1]
-                instance = self.get_instance(model_class, pk)
-                current_index.remove_object(instance, using=self.using)
-                pks.append(pk)
+                current_index.remove_object(obj_identifier, using=self.using)
+                pks.append(self.split_obj_identifier(obj_identifier)[1])
                 self.processed_deletes.add(obj_identifier)
 
             self.log.debug("Deleted objects for '%s': %s" % (object_path, ", ".join(pks)))

--- a/queued_search/signals.py
+++ b/queued_search/signals.py
@@ -2,7 +2,7 @@ from queues import queues
 from django.db import models
 from haystack.signals import BaseSignalProcessor
 from haystack.utils import get_identifier
-from queued_search.utils import get_queue_name
+from queued_search.utils import get_queue_name, rec_getattr
 
 
 class QueuedSignalProcessor(BaseSignalProcessor):
@@ -15,6 +15,24 @@ class QueuedSignalProcessor(BaseSignalProcessor):
         models.signals.post_delete.disconnect(self.enqueue_delete)
 
     def enqueue_save(self, sender, instance, **kwargs):
+        try:
+            filter_fields = instance.queue_filter()
+        except AttributeError:
+            filter_fields = {}
+        # Make sure filter fields are all set to acceptable value, otherwise delete
+        for filter_field, filter_values in filter_fields.items():
+            if rec_getattr(instance, filter_field) not in filter_values:
+                return self.enqueue('delete', instance)
+
+        try:
+            exclude_fields = instance.queue_exclude()
+        except AttributeError:
+            exclude_fields = {}
+        # Make sure exclude fields are not set to unacceptable value, otherwise delete
+        for exclude_field, exclude_values in exclude_fields.items():
+            if rec_getattr(instance, exclude_field) in exclude_values:
+                return self.enqueue('delete', instance)
+
         return self.enqueue('update', instance)
 
     def enqueue_delete(self, sender, instance, **kwargs):

--- a/queued_search/signals.py
+++ b/queued_search/signals.py
@@ -1,7 +1,7 @@
 from queues import queues
 from django.db import models
 from haystack.signals import BaseSignalProcessor
-from haystack.utils import get_identifier
+from haystack.utils import default_get_identifier
 from queued_search.utils import get_queue_name, rec_getattr
 
 
@@ -48,6 +48,6 @@ class QueuedSignalProcessor(BaseSignalProcessor):
             # ...or...
             ``delete:weblog.entry.8``
         """
-        message = "%s:%s" % (action, get_identifier(instance))
+        message = "%s:%s" % (action, default_get_identifier(instance))
         queue = queues.Queue(get_queue_name())
         return queue.write(message)

--- a/queued_search/utils.py
+++ b/queued_search/utils.py
@@ -11,3 +11,20 @@ def get_queue_name():
     for sanity.
     """
     return getattr(settings, 'SEARCH_QUEUE_NAME', 'haystack_search_queue')
+
+
+def rec_getattr(obj, attr):
+    """Get object's attribute. May use dot notation.
+
+    >>> class C(object): pass
+    >>> a = C()
+    >>> a.b = C()
+    >>> a.b.c = 4
+    >>> rec_getattr(a, 'b.c')
+    4
+    """
+    if '.' not in attr:
+        return getattr(obj, attr)
+    else:
+        L = attr.split('.')
+        return rec_getattr(getattr(obj, L[0]), '.'.join(L[1:]))


### PR DESCRIPTION
This just needlessly bloats up the queue and spams with errors messages like "index not found".. no need for all this.
