### PR TITLE
Don't queue objects that don't have a SearchIndex

### DIFF
--- a/queued_search/signals.py
+++ b/queued_search/signals.py
@@ -1,5 +1,7 @@
 from queues import queues
 from django.db import models
+from haystack import connections
+from haystack.exceptions import NotHandled
 from haystack.signals import BaseSignalProcessor
 from haystack.utils import get_identifier
 from queued_search.utils import get_queue_name
@@ -30,6 +32,13 @@ class QueuedSignalProcessor(BaseSignalProcessor):
             # ...or...
             ``delete:weblog.entry.8``
         """
+        
+        """But first check if the model even has a ``SearchIndex`` implementation."""
+        try:
+            connections['default'].get_unified_index().get_index(instance.__class__)
+        except NotHandled:
+            return False
+        
         message = "%s:%s" % (action, get_identifier(instance))
         queue = queues.Queue(get_queue_name())
         return queue.write(message)


### PR DESCRIPTION
This just needlessly bloats up the queue and spams with errors messages like "index not found".. no need for all this.

Cleaned branch from https://github.com/django-haystack/queued_search/pull/11

Apologies about the previous mess.
